### PR TITLE
Update Monastic to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "codecov": "^3.0.0",
     "eslint": "^5.1.0",
     "eslint-config-warp": "^3.0.0",
-    "esm": "^3.0.84",
+    "esm": "git+https://git@github.com/dicearr/esm.git#jsesm-from-mjs",
     "fluture": "^11.0.0",
     "mocha": "^6.1.2",
-    "monastic": "^1.0.1",
+    "monastic": "git+https://git@github.com/wearereasonablepeople/monastic.git#diego/esm-first",
     "nyc": "^14.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.2.0",
@@ -48,6 +48,6 @@
   },
   "peerDependencies": {
     "fluture": "<12.0.0",
-    "monastic": "^1.0.1"
+    "monastic": "git+https://git@github.com/wearereasonablepeople/monastic.git#diego/esm-first"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -141,17 +141,14 @@ suite ('Momi', function() {
   });
 
   test ('.go', function() {
-    var app = compose (
-      go (function*(next) {
-        yield modify (mul3);
-        return yield next;
-      }),
-      go (function*(next) {
-        yield next;
-        yield modify (eq (6));
-        return 42;
-      })
-    );
+    var app = compose (go (function*(next) {
+      yield modify (mul3);
+      return yield next;
+    })) (go (function*(next) {
+      yield next;
+      yield modify (eq (6));
+      return 42;
+    }));
     return assertResolved (run (app, 2), 42);
   });
 


### PR DESCRIPTION
## Motivation

Test how consumers of Monastic would need to modify their libraries if https://github.com/wearereasonablepeople/monastic/pull/15 gets merged.

## Changes

Ideally they wouldn't have to modify anything. However:

- Libraries using `esm` are going to crash as Monastic now exports ESM code from `.js` files.